### PR TITLE
Add option to set flat preview layout 'horizontal'/'vertical'

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Options:
   -pcp, --previewCubePath <path>             Path and name of preview image (default: "preview.q.jpg")
   -pcq, --previewCubeJpgQuality <percent>    Preview quality in percent (default: "85")
   -pfp, --previewFlatPath <path>             Path and name of preview image (default: "preview.f.jpg")
-  -pfo, --previewFlatOrder <path>            Face order from left to right (default: "bdflru")
+  -pfo, --previewFlatOrder <path>            Face order in the given layout direction (default: "bdflru")
+  -pfl, --previewFlatLayout <direction>      Face order direction, horizontal or vertical, "horizontal"
   -pfq, --previewFlatJpgQuality <percent>    Preview quality in percent (default: "85")
   -psp, --previewScaledPath <path>           Path and name of preview image (default: "preview.s.jpg")
   -psf, --previewScaledFactor <path>         Factor for one Downscaling (default: "1.4142135623730951")

--- a/src/cli.js
+++ b/src/cli.js
@@ -42,7 +42,8 @@ program
     .option('-pcp, --previewCubePath <path>', 'Path and name of preview image', 'preview.q.jpg')
     .option('-pcq, --previewCubeJpgQuality <percent>', 'Preview quality in percent', '85')
     .option('-pfp, --previewFlatPath <path>', 'Path and name of preview image', 'preview.f.jpg')
-    .option('-pfo, --previewFlatOrder <path>', 'Face order from left to right', 'bdflru')
+    .option('-pfo, --previewFlatOrder <path>', 'Face order in the given layout direction', 'bdflru')
+    .option('-pfl, --previewFlatLayout <direction>', 'Face order direction, horizontal or vertical', 'horizontal')
     .option('-pfq, --previewFlatJpgQuality <percent>', 'Preview quality in percent', '85')
     .option('-psp, --previewScaledPath <path>', 'Path and name of preview image', 'preview.s.jpg')
     .option('-psf, --previewScaledFactor <path>', 'Factor for one Downscaling', '2')
@@ -125,6 +126,7 @@ if (program.source.endsWith('.json')) {
         previewFlatPath: program.previewFlatPath,
         previewFlatJpgQuality: parseInt(program.previewFlatJpgQuality, 10),
         previewFlatOrder: program.previewFlatOrder,
+        previewFlatLayout: program.previewFlatLayout,
         previewScaledPath: program.previewScaledPath,
         previewScaledFactor: parseFloat(program.previewScaledFactor),
         previewScaledJpgQuality: parseInt(program.previewScaledJpgQuality, 10),

--- a/src/converter.js
+++ b/src/converter.js
@@ -375,21 +375,40 @@ function previewCube(config, srcImage, outerWidth, xOff, yOff, previewCubedPath)
 function previewFlat(config, srcImage, outerWidth, xOff, yOff, previewCubedPath) {
     const sw = new Stopwatch().begin();
 
-    const faceW = Math.floor(config.previewWidth / 6);
+    let faceW;
+    let faceH;
+    let faceSize;
+
+    if (config.previewFlatLayout === 'vertical') {
+        faceW = Math.floor(config.previewWidth);
+        faceH = Math.floor(config.previewWidth) * 6;
+        faceSize = Math.floor(config.previewWidth);
+    } else {
+        faceW = Math.floor(config.previewWidth / 6) * 6;
+        faceH = Math.floor(config.previewWidth / 6);
+        faceSize = Math.floor(config.previewWidth / 6);
+    }
+
     console.log()
     console.log('+------------------------------------------------------------------------')
-    console.log(`| Render flat preview(${faceW * 6}x${faceW}; xOff: ${xOff}, yOff:${yOff})`)
+    console.log(`| Render flat preview(${faceW}x${faceH}; xOff: ${xOff}, yOff:${yOff})`)
     console.log('+------------------------------------------------------------------------')
 
-    const result = new IMG().create(faceW * 6, faceW);
+    const result = new IMG().create(faceW, faceH);
     const faceRenderer = new FaceRenderer(srcImage, outerWidth, xOff, yOff);
 
     let faceOffset = 0;
     for (const f of config.previewFlatOrder) {
         const face = defaultFaceNames[f];
-        let faceImg = faceRenderer.render(face.index, faceW);
-        result.drawImg(faceImg, faceOffset, 0);
-        faceOffset += faceW;
+        let faceImg = faceRenderer.render(face.index, faceSize);
+
+        if (config.previewFlatLayout === 'vertical') {
+            result.drawImg(faceImg, 0, faceOffset);
+        } else {
+            result.drawImg(faceImg, faceOffset, 0);
+        }
+
+        faceOffset += faceSize;
     }
 
     result.write(previewCubedPath, {jpgQuality: config.previewFlatJpgQuality});


### PR DESCRIPTION
Allows setting the layout for the flat preview image to either `horizontal` or `vertical`. 